### PR TITLE
Include instructions on wrapper-use with selfhosted LicenseGate Instances

### DIFF
--- a/self-hosting/index.md
+++ b/self-hosting/index.md
@@ -163,3 +163,11 @@ RESET_PASSWORD_URL=https://licensegate.example.com/auth/password
 CORS_ORIGIN=https://licensegate.example.com
 GOOGLE_AUTH_CLIENT_ID=none
 ```
+
+## Setting up your plugin with the java wrapper
+LicenseGate, by default, uses its own license server that is provided under `api.licensegate.io`. In order to use your own licensing server, you'll need to setup the follwing:
+```java
+LicenseGate licenseGate = new LicenseGate("YOUR_USER_ID");
+licenseGate.setValidationServer("https://license.yourdomain.com");
+```
+Once this is done, license validation should now go through your own licensing server instead of the cloud-hosted one from LicenseGate.

--- a/self-hosting/index.md
+++ b/self-hosting/index.md
@@ -164,10 +164,6 @@ CORS_ORIGIN=https://licensegate.example.com
 GOOGLE_AUTH_CLIENT_ID=none
 ```
 
-## Setting up your plugin with the java wrapper
-LicenseGate, by default, uses its own license server that is provided under `api.licensegate.io`. In order to use your own licensing server, you'll need to setup the follwing:
-```java
-LicenseGate licenseGate = new LicenseGate("YOUR_USER_ID");
-licenseGate.setValidationServer("https://license.yourdomain.com");
-```
-Once this is done, license validation should now go through your own licensing server instead of the cloud-hosted one from LicenseGate.
+## Usage with wrappers
+LicenseGate wrapper libraries, by default, use the public LicenseGate server which is provided under `api.licensegate.io`. In order to use your self-hosted licensing server, you will need to configure your server url when using wrappers.
+Refer to the wrapper documentation for detailed instructions.

--- a/wrappers/java.md
+++ b/wrappers/java.md
@@ -131,3 +131,9 @@ boolean isValid = new LicenseGate("YOUR_USER_ID")
 // Having trouble? Enable debug mode
 new LicenseGate("YOUR_USER_ID").debug().verify("LICENSE_KEY");
 ```
+
+#### Using your own LicenseGate server
+
+```java
+new LicenseGate("YOUR_USER_ID").setValidationServer("https://example.com").verify("LICENSE_KEY");
+```

--- a/wrappers/java.md
+++ b/wrappers/java.md
@@ -102,7 +102,8 @@ if (result == LicenseGate.ValidationType.VALID) {
 
 ```java
 // Your public RSA key (can be found in your settings)
-final String PUBLIC_KEY = "-----BEGIN PUBLIC KEY----- MIIB2d/...";
+// Ensure to fully include it as is on your settings, do not cut away the "begin" and "end" of it
+final String PUBLIC_KEY = "-----BEGIN PUBLIC KEY----- MIIB2d/... -----END PUBLIC KEY-----";
 
 // Initialize the LicenseGate client
 LicenseGate licenseGate = new LicenseGate("YOUR_USER_ID", PUBLIC_KEY);
@@ -135,5 +136,6 @@ new LicenseGate("YOUR_USER_ID").debug().verify("LICENSE_KEY");
 #### Using your own LicenseGate server
 
 ```java
-new LicenseGate("YOUR_USER_ID").setValidationServer("https://example.com").verify("LICENSE_KEY");
+new LicenseGate("YOUR_USER_ID").setValidationServer("https://backend.example.com").verify("LICENSE_KEY");
 ```
+The URL should point to your LicenseGate backend server, not the web interface.

--- a/wrappers/java.md
+++ b/wrappers/java.md
@@ -60,6 +60,8 @@ dependencies {
 }
 ```
 
+Replacing 1.X.X with the latest version provided on the [Maven Repository](https://maven.respark.dev/#/releases/dev/respark/licensegate/license-gate/).
+
 ### Manual
 
 > Alternatively, you can also download the JAR file from the


### PR DESCRIPTION
[LicenseGate Java Wrapper with the specific Method](https://github.com/DevLeoko/license-gate-java-wrapper/blob/81b0c12c023bd8f463606dacb58915a839d50cfc/src/main/java/dev/respark/licensegate/LicenseGate.java#L78)

![image](https://github.com/DevLeoko/license-gate-docs/assets/47116705/6b89a402-a273-4765-bca7-f016115bc614)
